### PR TITLE
feat: add page load timeout and logging

### DIFF
--- a/app/browser.py
+++ b/app/browser.py
@@ -32,4 +32,6 @@ def create_driver(cfg: Dict) -> webdriver.Chrome:
             proxy = random.choice(proxies)
             options.add_argument(f"--proxy-server={proxy}")
     driver = webdriver.Chrome(options=options)
+    timeout = cfg.get("page_load_timeout", 30)
+    driver.set_page_load_timeout(timeout)
     return driver

--- a/app/crawler.py
+++ b/app/crawler.py
@@ -37,6 +37,10 @@ def crawl_author(author_url: str, cfg: Dict, store: storage.Storage) -> List[par
 
 def crawl_from_file(file_path: str, cfg: Dict) -> None:
     authors = utils.load_authors(file_path)
+    if not authors:
+        logger.warning(f"no authors found in {file_path}")
+        return
+
     store = storage.Storage(
         save_json=cfg.get("storage", {}).get("save_json", True),
         save_text=cfg.get("storage", {}).get("save_text", True),
@@ -44,8 +48,10 @@ def crawl_from_file(file_path: str, cfg: Dict) -> None:
     )
     for author_url in authors:
         try:
+            logger.info(f"crawling {author_url}")
             arts = crawl_author(author_url, cfg, store)
             storage.save_articles(arts, store)
+            logger.info(f"saved {len(arts)} articles for {author_url}")
         except Exception as exc:  # noqa: BLE001
             logger.error(f"error crawling {author_url}: {exc}")
     store.close()

--- a/config.yaml
+++ b/config.yaml
@@ -14,6 +14,7 @@ browser:
   use_proxy: false
   proxy_file: data/proxies.txt
   user_agent: ""
+  page_load_timeout: 30
 
 throttle:
   min_delay: 1.0

--- a/修复.md
+++ b/修复.md
@@ -1,0 +1,26 @@
+# 修复说明
+
+## 问题
+
+运行 `python -m app.main run` 时，如果网络环境不佳或目标页面加载缓慢，Selenium 默认会一直等待，终端看起来没有任何输出。
+
+## 修复
+
+1. 在 `app/browser.py` 中为 Chrome WebDriver 设置 `page_load_timeout`（默认 30 秒），避免无限等待。
+2. 在 `app/crawler.py` 中增加爬取进度日志，并在作者列表为空时给出警告。
+3. 在 `config.yaml` 的 `browser` 部分新增 `page_load_timeout` 配置项，可按需调整。
+
+## 使用方法
+
+保持原有命令不变：
+
+```bash
+python -m app.main run --limit-per-author 5
+```
+
+如需修改加载超时时间，可编辑 `config.yaml`：
+
+```yaml
+browser:
+  page_load_timeout: 30  # 单位：秒
+```


### PR DESCRIPTION
## Summary
- avoid indefinite waiting by adding page load timeout to Chrome driver
- log crawling progress and warn when authors list empty
- document fix in 修复.md and expose `page_load_timeout` in config

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c639e66b78832d8aa8349fae52bdab